### PR TITLE
Add FastAPI skeleton and project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # masterbrain2.0
+
+## Project Structure
+
+```
+masterbrain2.0/
+├── main.py
+├── requirements.txt
+└── README.md
+```
+
+## FastAPI Application
+
+The `main.py` file provides a minimal FastAPI application with a POST `/ingest` endpoint that echoes a confirmation response and a root health check endpoint. Install dependencies with `pip install -r requirements.txt` and start the server using:
+
+```
+uvicorn main:app --reload
+```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,24 @@
+"""Application entrypoint for the masterbrain2.0 FastAPI service."""
+from typing import Any, Dict
+
+from fastapi import FastAPI
+
+
+app = FastAPI(title="MasterBrain 2.0 API")
+
+
+def build_ingest_response(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Create a simple acknowledgement response for ingest requests."""
+    return {"status": "received", "payload": payload}
+
+
+@app.post("/ingest")
+async def ingest(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Accept payload data and return a confirmation response."""
+    return build_ingest_response(payload)
+
+
+@app.get("/")
+async def read_root() -> Dict[str, str]:
+    """Basic health check endpoint."""
+    return {"message": "MasterBrain 2.0 API is running"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+mem0


### PR DESCRIPTION
## Summary
- add initial FastAPI application with ingest endpoint and health check
- define helper function returning JSON acknowledgement
- document project layout and add dependencies list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d34f9afe388324ad64a4e5ce649596