### PR TITLE
Add start script for uvicorn server

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+uvicorn main:app --host 0.0.0.0 --port $PORT


### PR DESCRIPTION
## Summary
- add a start.sh script that starts the FastAPI app with uvicorn on the provided port
- ensure the script is executable for deployment environments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d353b32d548324849550e35b6cad09