### PR TITLE
Remove unavailable mem0 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 fastapi
 uvicorn
-mem0


### PR DESCRIPTION
## Summary
- remove the mem0 dependency because it is not published on PyPI and prevents installs

## Testing
- pip install -r requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68d3564ac7fc832498d201aca5109cea