### PR TITLE
Add mem0-aware ingest endpoint and deployment tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,55 @@
 ```
 masterbrain2.0/
 ├── main.py
+├── railway.json
 ├── requirements.txt
+├── start.sh
 └── README.md
 ```
 
 ## FastAPI Application
 
-The `main.py` file provides a minimal FastAPI application with a POST `/ingest` endpoint that echoes a confirmation response and a root health check endpoint. Install dependencies with `pip install -r requirements.txt` and start the server using:
+The FastAPI service exposes two endpoints:
 
-```
-uvicorn main:app --reload
-```
+- `POST /ingest` &ndash; accepts commit metadata and persists it through `mem0.add_memory` when the dependency is available. The
+  JSON response includes the original payload, whether mem0 is enabled, and an optional memory reference.
+- `GET /` &ndash; a lightweight health check endpoint suitable for uptime probes.
+
+### Local Development
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Launch the API with the helper script (defaults to port `8000` if `PORT` is unset):
+
+   ```bash
+   ./start.sh
+   ```
+
+3. Navigate to `http://127.0.0.1:8000/docs` to access the interactive Swagger UI. Execute the `POST /ingest` request with sample
+   commit data (for example, SHA, author, and message) and confirm that the response contains `"status": "received"`.
+
+### Railway Deployment
+
+Railway reads `railway.json` during deployments and executes `./start.sh`, ensuring that the service binds to the platform-provided
+port. Configure any required environment variables (such as credentials for mem0) in the Railway dashboard.
+
+### mem0 Troubleshooting
+
+The `mem0` package is listed in `requirements.txt`, but it may not be publicly available. If you encounter an import error or see a
+`mem0.add_memory is unavailable` warning in the API response:
+
+1. Confirm whether mem0 is distributed privately (for example, a Git repository or internal package index). Update
+   `requirements.txt` with the appropriate reference, such as `mem0 @ git+https://github.com/example/mem0.git`.
+2. Reinstall dependencies after updating the requirement specification:
+
+   ```bash
+   pip install --upgrade -r requirements.txt
+   ```
+
+3. Restart the FastAPI service (`./start.sh`) so the new dependency is loaded.
+4. Repeat the Swagger UI smoke test (`POST /ingest`) to verify that the response now includes a `memory_reference` key, which
+   indicates that `mem0.add_memory` executed successfully.

--- a/main.py
+++ b/main.py
@@ -1,20 +1,60 @@
 """Application entrypoint for the masterbrain2.0 FastAPI service."""
-from typing import Any, Dict
+from __future__ import annotations
 
-from fastapi import FastAPI
+import logging
+from typing import Any, Dict, Optional
 
+from fastapi import FastAPI, HTTPException, status
+
+try:  # pragma: no cover - executed at import time
+    import mem0  # type: ignore
+except ImportError:  # pragma: no cover - executed when dependency missing
+    mem0 = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="MasterBrain 2.0 API")
 
 
+def store_commit_payload(payload: Dict[str, Any]) -> Optional[Any]:
+    """Persist commit payload data with mem0 if the integration is available."""
+
+    if mem0 is None or not hasattr(mem0, "add_memory"):
+        logger.warning(
+            "mem0.add_memory is unavailable; commit payload was not persisted."
+        )
+        return None
+
+    try:
+        return mem0.add_memory(payload)  # type: ignore[attr-defined]
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.exception("mem0.add_memory failed: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to persist commit data to mem0.",
+        ) from exc
+
+
 def build_ingest_response(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Create a simple acknowledgement response for ingest requests."""
-    return {"status": "received", "payload": payload}
+    """Create a structured acknowledgement response for ingest requests."""
+    memory_reference = store_commit_payload(payload)
+
+    response: Dict[str, Any] = {
+        "status": "received",
+        "payload": payload,
+        "mem0_enabled": memory_reference is not None,
+    }
+
+    if memory_reference is not None:
+        response["memory_reference"] = memory_reference
+
+    return response
 
 
 @app.post("/ingest")
 async def ingest(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Accept payload data and return a confirmation response."""
+    """Accept commit payload data and persist it through mem0 when available."""
     return build_ingest_response(payload)
 
 

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "deploy": {
+    "startCommand": "./start.sh"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+mem0

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
-uvicorn main:app --host 0.0.0.0 --port $PORT
+set -euo pipefail
+
+PORT="${PORT:-8000}"
+
+exec uvicorn main:app --host 0.0.0.0 --port "${PORT}"


### PR DESCRIPTION
## Summary
- enhance the ingest endpoint to persist commit payloads through mem0 when available and report persistence status
- add Railway deployment configuration and harden the start script to respect provided ports
- document setup, smoke testing, deployment steps, and mem0 troubleshooting guidance

## Testing
- `curl -sSf http://127.0.0.1:8000/docs | head -n 5`
- `curl -sS -X POST http://127.0.0.1:8000/ingest -H 'Content-Type: application/json' -d '{"commit_sha":"abc123","author":"Alice","message":"Initial commit"}' | jq`


------
https://chatgpt.com/codex/tasks/task_e_68d35ce7bdc083248d35e6ce1362391f