### PR TITLE
Fix dependency name for mem0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 fastapi
 uvicorn
-mem0
+mem0ai


### PR DESCRIPTION
## Summary
- update the requirements to reference the correct mem0ai package

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d371007124832483e45700964e2f42